### PR TITLE
Add support for default values and migrations

### DIFF
--- a/db/migrations/001_create_users.cr
+++ b/db/migrations/001_create_users.cr
@@ -3,7 +3,11 @@ class CreateUsers::V001 < LuckyMigrator::Migration::V1
     create :users do
       add first_name : String, index: true
       add last_name : String
+      add age : Int32, default: 1
+      add num : Int64?, default: 1
       add salary : Float, precision: 10, scale: 2
+      add completed : Bool, default: false
+      add joined_at : Time, default: :now
     end
 
     create_index :users, :last_name, unique: true

--- a/db/migrations/001_create_users.cr
+++ b/db/migrations/001_create_users.cr
@@ -5,7 +5,7 @@ class CreateUsers::V001 < LuckyMigrator::Migration::V1
       add last_name : String
       add age : Int32, default: 1
       add num : Int64?, default: 1
-      add salary : Float, precision: 10, scale: 2
+      add salary : Float, precision: 10, scale: 2, default: 1.0
       add completed : Bool, default: false
       add joined_at : Time, default: :now
     end

--- a/spec/create_table_statement_spec.cr
+++ b/spec/create_table_statement_spec.cr
@@ -26,6 +26,37 @@ describe LuckyMigrator::CreateTableStatement do
     SQL
   end
 
+  it "sets default values" do
+    future_time = Time.new(2030,1,1)
+
+    built = LuckyMigrator::CreateTableStatement.new(:users).build do
+      add name : String, default: "name"
+      add email : String?, default: "optional"
+      add age : Int32, default: 1
+      add num : Int64, default: 1
+      add amount_paid : Float, default: 1.0
+      add completed : Bool, default: false
+      add joined_at : Time, default: :now
+      add future_time : Time, default: future_time
+    end
+
+    built.statements.size.should eq 1
+    built.statements.first.should eq <<-SQL
+    CREATE TABLE users (
+      id serial PRIMARY KEY,
+      created_at timestamptz NOT NULL,
+      updated_at timestamptz NOT NULL,
+      name text NOT NULL DEFAULT 'name',
+      email text DEFAULT 'optional',
+      age int NOT NULL DEFAULT 1,
+      num bigint NOT NULL DEFAULT 1,
+      amount_paid decimal NOT NULL DEFAULT 1.0,
+      completed boolean NOT NULL DEFAULT false,
+      joined_at timestamptz NOT NULL DEFAULT NOW(),
+      future_time timestamptz NOT NULL DEFAULT '#{future_time.to_utc}');
+    SQL
+  end
+
   describe "indices" do
     it "can create tables with indices" do
       built = LuckyMigrator::CreateTableStatement.new(:users).build do

--- a/spec/create_table_statement_spec.cr
+++ b/spec/create_table_statement_spec.cr
@@ -57,6 +57,16 @@ describe LuckyMigrator::CreateTableStatement do
     SQL
   end
 
+  it "raises on Int32 column with Int64 default" do
+    future_time = Time.new(2030,1,1)
+
+    expect_raises Exception, "Cannot set Int64 default for Int32 column 'age'. Either set the type to Int64 or change the default value." do
+      built = LuckyMigrator::CreateTableStatement.new(:users).build do
+        add age : Int32, default: 3_000_000_000
+      end
+    end
+  end
+
   describe "indices" do
     it "can create tables with indices" do
       built = LuckyMigrator::CreateTableStatement.new(:users).build do

--- a/spec/create_table_statement_spec.cr
+++ b/spec/create_table_statement_spec.cr
@@ -62,7 +62,7 @@ describe LuckyMigrator::CreateTableStatement do
 
     expect_raises Exception, "Cannot set Int64 default for Int32 column 'age'. Either set the type to Int64 or change the default value." do
       built = LuckyMigrator::CreateTableStatement.new(:users).build do
-        add age : Int32, default: 3_000_000_000
+        add age : Int32, default: 2_147_483_648
       end
     end
   end

--- a/spec/create_table_statement_spec.cr
+++ b/spec/create_table_statement_spec.cr
@@ -27,8 +27,6 @@ describe LuckyMigrator::CreateTableStatement do
   end
 
   it "sets default values" do
-    future_time = Time.new(2030,1,1)
-
     built = LuckyMigrator::CreateTableStatement.new(:users).build do
       add name : String, default: "name"
       add email : String?, default: "optional"
@@ -37,7 +35,7 @@ describe LuckyMigrator::CreateTableStatement do
       add amount_paid : Float, default: 1.0
       add completed : Bool, default: false
       add joined_at : Time, default: :now
-      add future_time : Time, default: future_time
+      add future_time : Time, default: Time.new
     end
 
     built.statements.size.should eq 1
@@ -53,18 +51,8 @@ describe LuckyMigrator::CreateTableStatement do
       amount_paid decimal NOT NULL DEFAULT 1.0,
       completed boolean NOT NULL DEFAULT false,
       joined_at timestamptz NOT NULL DEFAULT NOW(),
-      future_time timestamptz NOT NULL DEFAULT '#{future_time.to_utc}');
+      future_time timestamptz NOT NULL DEFAULT '#{Time.new.to_utc}');
     SQL
-  end
-
-  it "raises on Int32 column with Int64 default" do
-    future_time = Time.new(2030,1,1)
-
-    expect_raises Exception, "Cannot set Int64 default for Int32 column 'age'. Either set the type to Int64 or change the default value." do
-      built = LuckyMigrator::CreateTableStatement.new(:users).build do
-        add age : Int32, default: 2_147_483_648
-      end
-    end
   end
 
   describe "indices" do

--- a/spec/create_table_statement_spec.cr
+++ b/spec/create_table_statement_spec.cr
@@ -21,7 +21,7 @@ describe LuckyMigrator::CreateTableStatement do
       age int NOT NULL,
       completed boolean NOT NULL,
       joined_at timestamptz NOT NULL,
-      amount_paid decimal(12,12) NOT NULL,
+      amount_paid decimal(10,2) NOT NULL,
       email text);
     SQL
   end

--- a/src/lucky_migrator/create_table_statement.cr
+++ b/src/lucky_migrator/create_table_statement.cr
@@ -3,7 +3,7 @@ class LuckyMigrator::CreateTableStatement
   private getter index_statements = [] of String
 
   alias ColumnType = String.class | Time.class | Int32.class | Int64.class | Bool.class | Float.class
-  alias ColumnDefaultType = String | Time | Int32 | Int64 | Float32 | Float64 | Bool | Symbol | Nil
+  alias ColumnDefaultType = String | Time | Int32 | Int64 | Float32 | Float64 | Bool | Symbol
 
   def initialize(@table_name : Symbol)
   end
@@ -75,7 +75,7 @@ class LuckyMigrator::CreateTableStatement
     {% end %}
   end
 
-  def add_column(name, type : ColumnType, optional = false, reference = nil, on_delete = :do_nothing, default : ColumnDefaultType = nil, options : NamedTuple? = nil)
+  def add_column(name, type : ColumnType, optional = false, reference = nil, on_delete = :do_nothing, default : ColumnDefaultType? = nil, options : NamedTuple? = nil)
 
     if options
       column_type_with_options = column_type(type, **options)

--- a/src/lucky_migrator/create_table_statement.cr
+++ b/src/lucky_migrator/create_table_statement.cr
@@ -2,7 +2,8 @@ class LuckyMigrator::CreateTableStatement
   private getter rows = [] of String
   private getter index_statements = [] of String
 
-  alias ColumnType = String | Time | Int32 | Int64 | Bool
+  alias ColumnType = String.class | Time.class | Int32.class | Int64.class | Bool.class | Float.class
+  alias ColumnDefaultType = String | Time | Int32 | Int64 | Bool | Symbol | Nil
 
   def initialize(@table_name : Symbol)
   end

--- a/src/lucky_migrator/create_table_statement.cr
+++ b/src/lucky_migrator/create_table_statement.cr
@@ -62,7 +62,7 @@ class LuckyMigrator::CreateTableStatement
   # Generates raw sql from a type declaration and options passed in as named
   # variables.
   macro add(type_declaration, index = false, using = :btree, unique = false, default = nil, **type_options)
-    {% options = type_options.empty? ? nil : type_options %})
+    {% options = type_options.empty? ? nil : type_options %}
 
     {% if type_declaration.type.is_a?(Union) %}
       add_column :{{ type_declaration.var }}, {{ type_declaration.type.types.first }}, optional: true, default: {{ default }}, options: {{ options }}

--- a/src/lucky_migrator/create_table_statement.cr
+++ b/src/lucky_migrator/create_table_statement.cr
@@ -3,7 +3,7 @@ class LuckyMigrator::CreateTableStatement
   private getter index_statements = [] of String
 
   alias ColumnType = String.class | Time.class | Int32.class | Int64.class | Bool.class | Float.class
-  alias ColumnDefaultType = String | Time | Int32 | Int64 | Bool | Symbol | Nil
+  alias ColumnDefaultType = String | Time | Int32 | Int64 | Float32 | Float64 | Bool | Symbol | Nil
 
   def initialize(@table_name : Symbol)
   end
@@ -75,7 +75,7 @@ class LuckyMigrator::CreateTableStatement
     {% end %}
   end
 
-  def add_column(name, type : (String | Time | Int32 | Int64 | Float | Bool).class, optional = false, reference = nil, on_delete = :do_nothing,default : String | Time | Int32 | Int64 | Float | Bool | Symbol | Nil = nil, options : NamedTuple? = nil)
+  def add_column(name, type : ColumnType, optional = false, reference = nil, on_delete = :do_nothing, default : ColumnDefaultType = nil, options : NamedTuple? = nil)
 
     if options
       column_type_with_options = column_type(type, **options)

--- a/src/lucky_migrator/create_table_statement.cr
+++ b/src/lucky_migrator/create_table_statement.cr
@@ -148,12 +148,12 @@ class LuckyMigrator::CreateTableStatement
     " DEFAULT #{default.to_f}"
   end
 
-  def default_value(type : Time.class, default : Time | Symbol)
-    if default.is_a?(Time)
-      return " DEFAULT '#{default.to_utc}'"
-    end
+  def default_value(type : Time.class, default : Time)
+    return " DEFAULT '#{default.to_utc}'"
+  end
 
-    if default.is_a?(Symbol) && default == :now
+  def default_value(type : Time.class, default : Symbol)
+    if default == :now
       return " DEFAULT NOW()"
     end
 

--- a/src/lucky_migrator/create_table_statement.cr
+++ b/src/lucky_migrator/create_table_statement.cr
@@ -149,15 +149,15 @@ class LuckyMigrator::CreateTableStatement
   end
 
   def default_value(type : Time.class, default : Time)
-    return " DEFAULT '#{default.to_utc}'"
+    " DEFAULT '#{default.to_utc}'"
   end
 
   def default_value(type : Time.class, default : Symbol)
     if default == :now
-      return " DEFAULT NOW()"
+      " DEFAULT NOW()"
+    else
+      raise "Unrecognized default value #{default} for a timestamptz. Please use :now for current timestamp."
     end
-
-    raise "Unrecognized default value #{default} for a timestamptz. Please use :now for current timestamp."
   end
 
   def column_type(type : String.class)

--- a/src/lucky_migrator/create_table_statement.cr
+++ b/src/lucky_migrator/create_table_statement.cr
@@ -2,6 +2,8 @@ class LuckyMigrator::CreateTableStatement
   private getter rows = [] of String
   private getter index_statements = [] of String
 
+  alias ColumnType = String | Time | Int32 | Int64 | Bool
+
   def initialize(@table_name : Symbol)
   end
 
@@ -145,7 +147,7 @@ class LuckyMigrator::CreateTableStatement
   end
 
   def default_value(type : Float.class, default : Float)
-    " DEFAULT #{default.to_f}"
+    " DEFAULT #{default}"
   end
 
   def default_value(type : Time.class, default : Time)


### PR DESCRIPTION
Closes #37 

Here's my first try at handling default values. The tests pass and the migrations work but the `CreateTableStatement` class is getting crowded.

I used overloading similar to the `column_type` methods. Is this the correct way to do it?