### PR TITLE
Add type specific options

### DIFF
--- a/db/migrations/001_create_users.cr
+++ b/db/migrations/001_create_users.cr
@@ -3,6 +3,7 @@ class CreateUsers::V001 < LuckyMigrator::Migration::V1
     create :users do
       add first_name : String, index: true
       add last_name : String
+      add salary : Float, precision: 10, scale: 2
     end
 
     create_index :users, :last_name, unique: true

--- a/spec/create_table_statement_spec.cr
+++ b/spec/create_table_statement_spec.cr
@@ -7,7 +7,7 @@ describe LuckyMigrator::CreateTableStatement do
       add age : Int32
       add completed : Bool
       add joined_at : Time
-      add amount_paid : Float, precision: 10, scale: 2
+      add amount_paid : Float, scale: 12
       add email : String?
     end
 
@@ -21,7 +21,7 @@ describe LuckyMigrator::CreateTableStatement do
       age int NOT NULL,
       completed boolean NOT NULL,
       joined_at timestamptz NOT NULL,
-      amount_paid decimal(10,2) NOT NULL,
+      amount_paid decimal(12,12) NOT NULL,
       email text);
     SQL
   end

--- a/spec/create_table_statement_spec.cr
+++ b/spec/create_table_statement_spec.cr
@@ -7,7 +7,7 @@ describe LuckyMigrator::CreateTableStatement do
       add age : Int32
       add completed : Bool
       add joined_at : Time
-      add amount_paid : Float, scale: 12
+      add amount_paid : Float, precision: 10, scale: 2
       add email : String?
     end
 

--- a/spec/create_table_statement_spec.cr
+++ b/spec/create_table_statement_spec.cr
@@ -7,7 +7,7 @@ describe LuckyMigrator::CreateTableStatement do
       add age : Int32
       add completed : Bool
       add joined_at : Time
-      add amount_paid : Float
+      add amount_paid : Float, precision: 10, scale: 2
       add email : String?
     end
 
@@ -21,7 +21,7 @@ describe LuckyMigrator::CreateTableStatement do
       age int NOT NULL,
       completed boolean NOT NULL,
       joined_at timestamptz NOT NULL,
-      amount_paid decimal NOT NULL,
+      amount_paid decimal(10,2) NOT NULL,
       email text);
     SQL
   end

--- a/src/lucky_migrator/create_table_statement.cr
+++ b/src/lucky_migrator/create_table_statement.cr
@@ -155,14 +155,6 @@ class LuckyMigrator::CreateTableStatement
     "decimal(#{precision},#{scale})"
   end
 
-  def column_type(type : Float.class, precision : Int32)
-    "decimal(#{precision})"
-  end
-
-  def column_type(type : Float.class, scale : Int32)
-    "decimal(#{scale},#{scale})"
-  end
-
   def null_fragment(optional)
     if optional
       ""

--- a/src/lucky_migrator/create_table_statement.cr
+++ b/src/lucky_migrator/create_table_statement.cr
@@ -74,7 +74,7 @@ class LuckyMigrator::CreateTableStatement
 
   def add_column(name, type : (String | Time | Int32 | Int64 | Float | Bool).class, optional = false, reference = nil, on_delete = :do_nothing, options : NamedTuple? = nil)
 
-    if options.is_a?(NamedTuple)
+    if options
       column_type_with_options = column_type(type, **options)
     else
       column_type_with_options = column_type(type)
@@ -153,6 +153,14 @@ class LuckyMigrator::CreateTableStatement
 
   def column_type(type : Float.class, precision : Int32, scale : Int32)
     "decimal(#{precision},#{scale})"
+  end
+
+  def column_type(type : Float.class, precision : Int32)
+    "decimal(#{precision})"
+  end
+
+  def column_type(type : Float.class, scale : Int32)
+    "decimal(#{scale},#{scale})"
   end
 
   def null_fragment(optional)

--- a/src/lucky_migrator/create_table_statement.cr
+++ b/src/lucky_migrator/create_table_statement.cr
@@ -58,11 +58,13 @@ class LuckyMigrator::CreateTableStatement
 
   # Generates raw sql from a type declaration and options passed in as named
   # variables.
-  macro add(type_declaration, index = false, using = :btree, unique = false)
+  macro add(type_declaration, index = false, using = :btree, unique = false, **type_options)
+    {% options = type_options.empty? ? nil : type_options %}
+
     {% if type_declaration.type.is_a?(Union) %}
-      add_column :{{ type_declaration.var }}, {{ type_declaration.type.types.first }}, optional: true
+      add_column :{{ type_declaration.var }}, {{ type_declaration.type.types.first }}, optional: true, options: {{ options }}
     {% else %}
-      add_column :{{ type_declaration.var }}, {{ type_declaration.type }}
+      add_column :{{ type_declaration.var }}, {{ type_declaration.type }}, options: {{ options }}
     {% end %}
 
     {% if index || unique %}
@@ -70,12 +72,19 @@ class LuckyMigrator::CreateTableStatement
     {% end %}
   end
 
-  def add_column(name, type : (String | Time | Int32 | Int64 | Float | Bool).class, optional = false, reference = nil, on_delete = :do_nothing)
+  def add_column(name, type : (String | Time | Int32 | Int64 | Float | Bool).class, optional = false, reference = nil, on_delete = :do_nothing, options : NamedTuple? = nil)
+
+    if options.is_a?(NamedTuple)
+      column_type_with_options = column_type(type, **options)
+    else
+      column_type_with_options = column_type(type)
+    end
+
     rows << String.build do |row|
       row << "  "
       row << name.to_s
       row << " "
-      row << column_type(type)
+      row << column_type_with_options
       row << null_fragment(optional)
       row << references(reference, on_delete)
     end
@@ -134,12 +143,16 @@ class LuckyMigrator::CreateTableStatement
     "bigint"
   end
 
+  def column_type(type : Bool.class)
+    "boolean"
+  end
+
   def column_type(type : Float.class)
     "decimal"
   end
 
-  def column_type(type : Bool.class)
-    "boolean"
+  def column_type(type : Float.class, precision : Int32, scale : Int32)
+    "decimal(#{precision},#{scale})"
   end
 
   def null_fragment(optional)


### PR DESCRIPTION
Closes #16.

You can add support for options by adding overloads like this:
```crystal
def column_type(type : Float.class, precision : Int32, scale : Int32)
  "decimal(#{precision},#{scale})"
end
```
I didn't add checks here because the database would throw if scale > precision, or either is null.