### PR TITLE
Add default and type specific options on alter

### DIFF
--- a/db/migrations/002_alter_users.cr
+++ b/db/migrations/002_alter_users.cr
@@ -2,7 +2,7 @@ class AlterUsers::V002 < LuckyMigrator::Migration::V1
   def migrate
     alter :users do
       remove :first_name
-      add name : String
+      add name : String, default: "Jon"
       add nickname : String?
     end
 

--- a/spec/alter_table_statement_spec.cr
+++ b/spec/alter_table_statement_spec.cr
@@ -30,7 +30,7 @@ describe LuckyMigrator::AlterTableStatement do
       add email : String?, default: "optional"
       add age : Int32, default: 1
       add num : Int64, default: 1
-      add amount_paid : Float, default: 1.0
+      add amount_paid : Float, default: 1.0, precision: 10, scale: 5
       add completed : Bool, default: false
       add joined_at : Time, default: :now
       add future_time : Time, default: Time.new
@@ -43,7 +43,7 @@ describe LuckyMigrator::AlterTableStatement do
       ADD email text DEFAULT 'optional',
       ADD age int NOT NULL DEFAULT 1,
       ADD num bigint NOT NULL DEFAULT 1,
-      ADD amount_paid decimal NOT NULL DEFAULT 1.0,
+      ADD amount_paid decimal(10,5) NOT NULL DEFAULT 1.0,
       ADD completed boolean NOT NULL DEFAULT false,
       ADD joined_at timestamptz NOT NULL DEFAULT NOW(),
       ADD future_time timestamptz NOT NULL DEFAULT '#{Time.new.to_utc}'

--- a/spec/alter_table_statement_spec.cr
+++ b/spec/alter_table_statement_spec.cr
@@ -2,7 +2,7 @@ require "./spec_helper"
 
 describe LuckyMigrator::AlterTableStatement do
   it "can alter tables" do
-    statement = LuckyMigrator::AlterTableStatement.new(:users).build do
+    built = LuckyMigrator::AlterTableStatement.new(:users).build do
       add name : String
       add age : Int32
       add completed : Bool
@@ -12,15 +12,41 @@ describe LuckyMigrator::AlterTableStatement do
       remove :old_field
     end
 
-    statement.should eq <<-SQL
+    built.statements.first.should eq <<-SQL
     ALTER TABLE users
       ADD name text NOT NULL,
       ADD age int NOT NULL,
       ADD completed boolean NOT NULL,
-      ADD joined_at timestamp NOT NULL,
+      ADD joined_at timestamptz NOT NULL,
       ADD amount_paid decimal NOT NULL,
       ADD email text,
       DROP old_field
+    SQL
+  end
+
+  it "sets default values" do
+    built = LuckyMigrator::AlterTableStatement.new(:users).build do
+      add name : String, default: "name"
+      add email : String?, default: "optional"
+      add age : Int32, default: 1
+      add num : Int64, default: 1
+      add amount_paid : Float, default: 1.0
+      add completed : Bool, default: false
+      add joined_at : Time, default: :now
+      add future_time : Time, default: Time.new
+    end
+
+    built.statements.size.should eq 1
+    built.statements.first.should eq <<-SQL
+    ALTER TABLE users
+      ADD name text NOT NULL DEFAULT 'name',
+      ADD email text DEFAULT 'optional',
+      ADD age int NOT NULL DEFAULT 1,
+      ADD num bigint NOT NULL DEFAULT 1,
+      ADD amount_paid decimal NOT NULL DEFAULT 1.0,
+      ADD completed boolean NOT NULL DEFAULT false,
+      ADD joined_at timestamptz NOT NULL DEFAULT NOW(),
+      ADD future_time timestamptz NOT NULL DEFAULT '#{Time.new.to_utc}'
     SQL
   end
 end

--- a/src/lucky_migrator/alter_table_statement.cr
+++ b/src/lucky_migrator/alter_table_statement.cr
@@ -4,9 +4,6 @@ class LuckyMigrator::AlterTableStatement
   include LuckyMigrator::ColumnTypeOptionHelpers
   include LuckyMigrator::ColumnDefaultHelpers
 
-  alias ColumnType = String.class | Time.class | Int32.class | Int64.class | Bool.class | Float.class
-  alias ColumnDefaultType = String | Time | Int32 | Int64 | Float32 | Float64 | Bool | Symbol
-
   getter statement = IO::Memory.new
   getter rows = [] of String
   getter dropped_rows = [] of String

--- a/src/lucky_migrator/alter_table_statement.cr
+++ b/src/lucky_migrator/alter_table_statement.cr
@@ -1,4 +1,12 @@
+require "./*"
+
 class LuckyMigrator::AlterTableStatement
+  include LuckyMigrator::ColumnTypeOptionHelpers
+  include LuckyMigrator::ColumnDefaultHelpers
+
+  alias ColumnType = String.class | Time.class | Int32.class | Int64.class | Bool.class | Float.class
+  alias ColumnDefaultType = String | Time | Int32 | Int64 | Float32 | Float64 | Bool | Symbol
+
   getter statement = IO::Memory.new
   getter rows = [] of String
   getter dropped_rows = [] of String
@@ -7,61 +15,52 @@ class LuckyMigrator::AlterTableStatement
   end
 
   def build
-    statement << "ALTER TABLE #{@table_name}"
-    statement << "\n"
     with self yield
-    process_rows
-    statement.to_s
+    self
   end
 
-  private def process_rows
-    statement << (rows + dropped_rows).join(",\n")
+  def statements
+    [alter_statement]
   end
 
-  macro add(type_declaration)
+  def alter_statement
+    String.build do |statement|
+      statement << "ALTER TABLE #{@table_name}"
+      statement << "\n"
+      statement << (rows + dropped_rows).join(",\n")
+    end
+  end
+
+  macro add(type_declaration, default = nil, **type_options)
+    {% options = type_options.empty? ? nil : type_options %}
+
     {% if type_declaration.type.is_a?(Union) %}
-      add_column :{{ type_declaration.var }}, {{ type_declaration.type.types.first }}, optional: true
+      add_column :{{ type_declaration.var }}, {{ type_declaration.type.types.first }}, optional: true, default: {{ default }}, options: {{ options }}
     {% else %}
-      add_column :{{ type_declaration.var }}, {{ type_declaration.type }}
+      add_column :{{ type_declaration.var }}, {{ type_declaration.type }}, default: {{ default }}, options: {{ options }}
     {% end %}
   end
 
-  def add_column(name : Symbol, type : (Bool | String | Time | Int32 | Int64 | Float).class, optional = false)
+  def add_column(name : Symbol, type : (Bool | String | Time | Int32 | Int64 | Float).class, optional = false, default : ColumnDefaultType? = nil, options : NamedTuple? = nil)
+
+    if options
+      column_type_with_options = column_type(type, **options)
+    else
+      column_type_with_options = column_type(type)
+    end
+
     rows << String.build do |row|
       row << "  ADD "
       row << name.to_s
       row << " "
-      row << column_type(type)
+      row << column_type_with_options
       row << null_fragment(optional)
+      row << default_value(type, default) unless default.nil?
     end
   end
 
   def remove(name : Symbol)
     dropped_rows << "  DROP #{name.to_s}"
-  end
-
-  def column_type(type : String.class)
-    "text"
-  end
-
-  def column_type(type : Time.class)
-    "timestamp"
-  end
-
-  def column_type(type : Int32.class)
-    "int"
-  end
-
-  def column_type(type : Int64.class)
-    "bigint"
-  end
-
-  def column_type(type : Float.class)
-    "decimal"
-  end
-
-  def column_type(type : Bool.class)
-    "boolean"
   end
 
   def null_fragment(optional)

--- a/src/lucky_migrator/alter_table_statement.cr
+++ b/src/lucky_migrator/alter_table_statement.cr
@@ -14,6 +14,26 @@ class LuckyMigrator::AlterTableStatement
   def initialize(@table_name : Symbol)
   end
 
+  # Accepts a block to alter a table using the `add` method. The generated sql
+  # statements are aggregated in the `statements` getter.
+  #
+  # ## Usage
+  #
+  # ```
+  # built = LuckyMigrator::AlterTableStatement.new(:users).build do
+  #   add name : String
+  #   add age : Int32
+  #   remove old_field
+  # end
+  #
+  # built.statements
+  # # => [
+  # "ALTER TABLE users
+  #   ADD name text NOT NULL,
+  #   ADD age int NOT NULL,
+  #   DROP old_field"
+  # ]
+  # ```
   def build
     with self yield
     self

--- a/src/lucky_migrator/alter_table_statement.cr
+++ b/src/lucky_migrator/alter_table_statement.cr
@@ -1,4 +1,5 @@
-require "./*"
+require "./column_default_helpers"
+require "./column_type_option_helpers"
 
 class LuckyMigrator::AlterTableStatement
   include LuckyMigrator::ColumnTypeOptionHelpers

--- a/src/lucky_migrator/column_default_helpers.cr
+++ b/src/lucky_migrator/column_default_helpers.cr
@@ -1,4 +1,6 @@
 module LuckyMigrator::ColumnDefaultHelpers
+  alias ColumnDefaultType = String | Time | Int32 | Int64 | Float32 | Float64 | Bool | Symbol
+
   def default_value(type : String.class, default : String)
     " DEFAULT '#{default}'"
   end

--- a/src/lucky_migrator/column_default_helpers.cr
+++ b/src/lucky_migrator/column_default_helpers.cr
@@ -1,0 +1,33 @@
+module LuckyMigrator::ColumnDefaultHelpers
+  def default_value(type : String.class, default : String)
+    " DEFAULT '#{default}'"
+  end
+
+  def default_value(type : Int64.class, default : Int32 | Int64)
+    " DEFAULT #{default}"
+  end
+
+  def default_value(type : Int32.class, default : Int32)
+    " DEFAULT #{default}"
+  end
+
+  def default_value(type : Bool.class, default : Bool)
+    " DEFAULT #{default}"
+  end
+
+  def default_value(type : Float.class, default : Float)
+    " DEFAULT #{default}"
+  end
+
+  def default_value(type : Time.class, default : Time)
+    " DEFAULT '#{default.to_utc}'"
+  end
+
+  def default_value(type : Time.class, default : Symbol)
+    if default == :now
+      " DEFAULT NOW()"
+    else
+      raise "Unrecognized default value #{default} for a timestamptz. Please use :now for current timestamp."
+    end
+  end
+end

--- a/src/lucky_migrator/column_type_option_helpers.cr
+++ b/src/lucky_migrator/column_type_option_helpers.cr
@@ -1,0 +1,29 @@
+module LuckyMigrator::ColumnTypeOptionHelpers
+  def column_type(type : String.class)
+    "text"
+  end
+
+  def column_type(type : Time.class)
+    "timestamptz"
+  end
+
+  def column_type(type : Int32.class)
+    "int"
+  end
+
+  def column_type(type : Int64.class)
+    "bigint"
+  end
+
+  def column_type(type : Bool.class)
+    "boolean"
+  end
+
+  def column_type(type : Float.class)
+    "decimal"
+  end
+
+  def column_type(type : Float.class, precision : Int32, scale : Int32)
+    "decimal(#{precision},#{scale})"
+  end
+end

--- a/src/lucky_migrator/column_type_option_helpers.cr
+++ b/src/lucky_migrator/column_type_option_helpers.cr
@@ -1,4 +1,6 @@
 module LuckyMigrator::ColumnTypeOptionHelpers
+  alias ColumnType = String.class | Time.class | Int32.class | Int64.class | Bool.class | Float.class
+
   def column_type(type : String.class)
     "text"
   end

--- a/src/lucky_migrator/create_table_statement.cr
+++ b/src/lucky_migrator/create_table_statement.cr
@@ -1,4 +1,7 @@
 class LuckyMigrator::CreateTableStatement
+  include LuckyMigrator::ColumnDefaultHelpers
+  include LuckyMigrator::ColumnTypeOptionHelpers
+
   private getter rows = [] of String
   private getter index_statements = [] of String
 
@@ -121,66 +124,6 @@ class LuckyMigrator::CreateTableStatement
 
     add_column :{{ foreign_key_name }}, Int64, {{ optional }}, reference: %table_name, on_delete: {{ on_delete }}
     add_index :{{ foreign_key_name }}
-  end
-
-  def default_value(type : String.class, default : String)
-    " DEFAULT '#{default}'"
-  end
-
-  def default_value(type : Int64.class, default : Int32 | Int64)
-    " DEFAULT #{default}"
-  end
-
-  def default_value(type : Int32.class, default : Int32)
-    " DEFAULT #{default}"
-  end
-
-  def default_value(type : Bool.class, default : Bool)
-    " DEFAULT #{default}"
-  end
-
-  def default_value(type : Float.class, default : Float)
-    " DEFAULT #{default}"
-  end
-
-  def default_value(type : Time.class, default : Time)
-    " DEFAULT '#{default.to_utc}'"
-  end
-
-  def default_value(type : Time.class, default : Symbol)
-    if default == :now
-      " DEFAULT NOW()"
-    else
-      raise "Unrecognized default value #{default} for a timestamptz. Please use :now for current timestamp."
-    end
-  end
-
-  def column_type(type : String.class)
-    "text"
-  end
-
-  def column_type(type : Time.class)
-    "timestamptz"
-  end
-
-  def column_type(type : Int32.class)
-    "int"
-  end
-
-  def column_type(type : Int64.class)
-    "bigint"
-  end
-
-  def column_type(type : Bool.class)
-    "boolean"
-  end
-
-  def column_type(type : Float.class)
-    "decimal"
-  end
-
-  def column_type(type : Float.class, precision : Int32, scale : Int32)
-    "decimal(#{precision},#{scale})"
   end
 
   def null_fragment(optional)

--- a/src/lucky_migrator/create_table_statement.cr
+++ b/src/lucky_migrator/create_table_statement.cr
@@ -5,9 +5,6 @@ class LuckyMigrator::CreateTableStatement
   private getter rows = [] of String
   private getter index_statements = [] of String
 
-  alias ColumnType = String.class | Time.class | Int32.class | Int64.class | Bool.class | Float.class
-  alias ColumnDefaultType = String | Time | Int32 | Int64 | Float32 | Float64 | Bool | Symbol
-
   def initialize(@table_name : Symbol)
   end
 

--- a/src/lucky_migrator/create_table_statement.cr
+++ b/src/lucky_migrator/create_table_statement.cr
@@ -27,8 +27,8 @@ class LuckyMigrator::CreateTableStatement
   # # => [
   #   "CREATE TABLE users (
   #     id serial PRIMARY KEY,
-  #     created_at timestamp NOT NULL,
-  #     updated_at timestamp NOT NULL,
+  #     created_at timestamptz NOT NULL,
+  #     updated_at timestamptz NOT NULL,
   #     account_id bigint NOT NULL REFERENCES accounts (id) ON DELETE CASCADE,
   #     email text NOT NULL);",
   #   "CREATE UNIQUE INDEX users_email_index ON users USING btree (email);"

--- a/src/lucky_migrator/statement_helpers.cr
+++ b/src/lucky_migrator/statement_helpers.cr
@@ -14,11 +14,13 @@ module LuckyMigrator::StatementHelpers
   end
 
   macro alter(table_name)
-    statement = LuckyMigrator::AlterTableStatement.new({{ table_name }}).build do
+    statements = LuckyMigrator::AlterTableStatement.new({{ table_name }}).build do
       {{ yield }}
-    end
+    end.statements
 
-    execute statement
+    statements.each do |statement|
+      execute statement
+    end
   end
 
   def create_foreign_key(from : Symbol, to : Symbol, column : Symbol, primary_key = :id, on_delete = :do_nothing)


### PR DESCRIPTION
Closes #51.

I refactored `default_value` and `column_type` methods into separate modules and updated the AlterTable class to match the CreateTable class.

The only issue I had was that the `include LuckyMigrator::ColumnDefaultHelpers` wasn't being respected and it kept giving me: `in src/lucky_migrator/alter_table_statement.cr:2: undefined constant LuckyMigrator::ColumnDefaultHelpers`.

So I added a `require "./*"` statement to handle it, but I don't think I should need that right?