### PR TITLE
Enforce default or fill_existing_with when adding required fields to an existing table

### DIFF
--- a/db/migrations/002_alter_users.cr
+++ b/db/migrations/002_alter_users.cr
@@ -14,7 +14,7 @@ class AlterUsers::V002 < LuckyMigrator::Migration::V1
     alter :users do
       remove :name
       remove :nickname
-      add first_name : String
+      add first_name : String, fill_existing_with: "Jon"
     end
   end
 end

--- a/spec/alter_table_statement_spec.cr
+++ b/spec/alter_table_statement_spec.cr
@@ -1,55 +1,42 @@
 require "./spec_helper"
 
 describe LuckyMigrator::AlterTableStatement do
-  it "can alter tables" do
+  it "can alter tables with defaults, indices and options" do
     built = LuckyMigrator::AlterTableStatement.new(:users).build do
-      add name : String
-      add age : Int32
-      add completed : Bool
-      add joined_at : Time
-      add amount_paid : Float
-      add email : String?
-      remove :old_field
-    end
-
-    built.statements.first.should eq <<-SQL
-    ALTER TABLE users
-      ADD name text NOT NULL,
-      ADD age int NOT NULL,
-      ADD completed boolean NOT NULL,
-      ADD joined_at timestamptz NOT NULL,
-      ADD amount_paid decimal NOT NULL,
-      ADD email text,
-      DROP old_field
-    SQL
-  end
-
-  it "sets default values and indices" do
-    built = LuckyMigrator::AlterTableStatement.new(:users).build do
-      add name : String, default: "name"
-      add email : String?, default: "optional"
+      add name : String?
+      add email : String, default: "user@lucky.com"
       add age : Int32, default: 1, unique: true
       add num : Int64, default: 1, index: true
       add amount_paid : Float, default: 1.0, precision: 10, scale: 5
       add completed : Bool, default: false
       add joined_at : Time, default: :now
       add future_time : Time, default: Time.new
+      remove :old_field
     end
 
     built.statements.size.should eq 3
     built.statements.first.should eq <<-SQL
     ALTER TABLE users
-      ADD name text NOT NULL DEFAULT 'name',
-      ADD email text DEFAULT 'optional',
+      ADD name text,
+      ADD email text NOT NULL DEFAULT 'user@lucky.com',
       ADD age int NOT NULL DEFAULT 1,
       ADD num bigint NOT NULL DEFAULT 1,
       ADD amount_paid decimal(10,5) NOT NULL DEFAULT 1.0,
       ADD completed boolean NOT NULL DEFAULT false,
       ADD joined_at timestamptz NOT NULL DEFAULT NOW(),
-      ADD future_time timestamptz NOT NULL DEFAULT '#{Time.new.to_utc}'
+      ADD future_time timestamptz NOT NULL DEFAULT '#{Time.new.to_utc}',
+      DROP old_field
     SQL
 
     built.statements[1].should eq "CREATE UNIQUE INDEX users_age_index ON users USING btree (age);"
     built.statements[2].should eq "CREATE INDEX users_num_index ON users USING btree (num);"
+  end
+
+  it "raises when adding a required column without a default" do
+    expect_raises Exception, "must provide a default value when adding a required column" do
+      LuckyMigrator::AlterTableStatement.new(:users).build do
+        add email : String
+      end
+    end
   end
 end

--- a/spec/alter_table_statement_spec.cr
+++ b/spec/alter_table_statement_spec.cr
@@ -10,11 +10,12 @@ describe LuckyMigrator::AlterTableStatement do
       add amount_paid : Float, default: 1.0, precision: 10, scale: 5
       add completed : Bool, default: false
       add joined_at : Time, default: :now
+      add updated_at : Time, fill_existing_with: :now
       add future_time : Time, default: Time.new
       remove :old_field
     end
 
-    built.statements.size.should eq 5
+    built.statements.size.should eq 7
     built.statements.first.should eq <<-SQL
     ALTER TABLE users
       ADD name text,
@@ -24,6 +25,7 @@ describe LuckyMigrator::AlterTableStatement do
       ADD amount_paid decimal(10,5) NOT NULL DEFAULT 1.0,
       ADD completed boolean NOT NULL DEFAULT false,
       ADD joined_at timestamptz NOT NULL DEFAULT NOW(),
+      ADD updated_at timestamptz,
       ADD future_time timestamptz NOT NULL DEFAULT '#{Time.new.to_utc}',
       DROP old_field
     SQL
@@ -32,6 +34,8 @@ describe LuckyMigrator::AlterTableStatement do
     built.statements[2].should eq "CREATE INDEX users_num_index ON users USING btree (num);"
     built.statements[3].should eq "UPDATE users SET email = 'noreply@lucky.com';"
     built.statements[4].should eq "ALTER TABLE users ALTER COLUMN email SET NOT NULL;"
+    built.statements[5].should eq "UPDATE users SET updated_at = NOW();"
+    built.statements[6].should eq "ALTER TABLE users ALTER COLUMN updated_at SET NOT NULL;"
   end
 
   it "raises when adding a required column without a default or fill_existing_with argument" do

--- a/src/lucky_migrator/alter_table_statement.cr
+++ b/src/lucky_migrator/alter_table_statement.cr
@@ -9,6 +9,7 @@ class LuckyMigrator::AlterTableStatement
 
   getter rows = [] of String
   getter dropped_rows = [] of String
+  getter fill_existing_with_statements = [] of String
 
   def initialize(@table_name : Symbol)
   end
@@ -39,7 +40,7 @@ class LuckyMigrator::AlterTableStatement
   end
 
   def statements
-    [alter_statement] + index_statements
+    [alter_statement] + index_statements + fill_existing_with_statements
   end
 
   def alter_statement
@@ -50,16 +51,18 @@ class LuckyMigrator::AlterTableStatement
     end
   end
 
-  macro add(type_declaration, index = false, using = :btree, unique = false, default = nil, **type_options)
+  macro add(type_declaration, index = false, using = :btree, unique = false, default = nil, fill_existing_with = nil, **type_options)
     {% options = type_options.empty? ? nil : type_options %}
 
     {% if type_declaration.type.is_a?(Union) %}
-      add_column :{{ type_declaration.var }}, {{ type_declaration.type.types.first }}, true, default: {{ default }}, options: {{ options }}
+      add_column :{{ type_declaration.var }}, {{ type_declaration.type.types.first }}, true, {{ default }}, nil, options: {{ options }}
     {% else %}
-      if {{ default }}.nil?
-        raise "must provide a default value when adding a required column"
+      if {{ default }}.nil? && {{ fill_existing_with }}.nil?
+        raise "You must provide a default value or use fill_existing_with when adding a required field to an existing table.\n
+          Example: add positive : Bool, fill_existing_with: false"
       end
-      add_column :{{ type_declaration.var }}, {{ type_declaration.type }}, false, default: {{ default }}, options: {{ options }}
+
+      add_column :{{ type_declaration.var }}, {{ type_declaration.type }}, false, {{ default }}, {{ fill_existing_with}}, options: {{ options }}
     {% end %}
 
     {% if index || unique %}
@@ -67,11 +70,16 @@ class LuckyMigrator::AlterTableStatement
     {% end %}
   end
 
-  def add_column(name : Symbol, type : ColumnType, optional = false, default : ColumnDefaultType? = nil, options : NamedTuple? = nil)
+  def add_column(name : Symbol, type : ColumnType, optional = false, default : ColumnDefaultType? = nil, fill_existing_with : ColumnDefaultType? = nil, options : NamedTuple? = nil)
     if options
       column_type_with_options = column_type(type, **options)
     else
       column_type_with_options = column_type(type)
+    end
+
+    if fill_existing_with
+      optional = true
+      add_fill_existing_with_statements(name, fill_existing_with)
     end
 
     rows << String.build do |row|
@@ -82,6 +90,14 @@ class LuckyMigrator::AlterTableStatement
       row << null_fragment(optional)
       row << default_value(type, default) unless default.nil?
     end
+  end
+
+  def add_fill_existing_with_statements(column : Symbol, value : ColumnDefaultType)
+    val = default_value(value.class, value).gsub(" DEFAULT ", "")
+    @fill_existing_with_statements = [
+      "UPDATE #{@table_name} SET #{column} = #{val};",
+      "ALTER TABLE #{@table_name} ALTER COLUMN #{column} SET NOT NULL;"
+    ]
   end
 
   def remove(name : Symbol)

--- a/src/lucky_migrator/alter_table_statement.cr
+++ b/src/lucky_migrator/alter_table_statement.cr
@@ -93,9 +93,8 @@ class LuckyMigrator::AlterTableStatement
   end
 
   def add_fill_existing_with_statements(column : Symbol, value : ColumnDefaultType)
-    val = default_value(value.class, value).gsub(" DEFAULT ", "")
     @fill_existing_with_statements = [
-      "UPDATE #{@table_name} SET #{column} = #{val};",
+      "UPDATE #{@table_name} SET #{column} = #{value_to_string(value)};",
       "ALTER TABLE #{@table_name} ALTER COLUMN #{column} SET NOT NULL;"
     ]
   end

--- a/src/lucky_migrator/alter_table_statement.cr
+++ b/src/lucky_migrator/alter_table_statement.cr
@@ -79,7 +79,7 @@ class LuckyMigrator::AlterTableStatement
 
     if fill_existing_with
       optional = true
-      add_fill_existing_with_statements(name, fill_existing_with)
+      add_fill_existing_with_statements(name, type, fill_existing_with)
     end
 
     rows << String.build do |row|
@@ -92,9 +92,9 @@ class LuckyMigrator::AlterTableStatement
     end
   end
 
-  def add_fill_existing_with_statements(column : Symbol, value : ColumnDefaultType)
-    @fill_existing_with_statements = [
-      "UPDATE #{@table_name} SET #{column} = #{value_to_string(value)};",
+  def add_fill_existing_with_statements(column : Symbol, type : ColumnType, value : ColumnDefaultType)
+    @fill_existing_with_statements += [
+      "UPDATE #{@table_name} SET #{column} = #{value_to_string(type, value)};",
       "ALTER TABLE #{@table_name} ALTER COLUMN #{column} SET NOT NULL;"
     ]
   end

--- a/src/lucky_migrator/alter_table_statement.cr
+++ b/src/lucky_migrator/alter_table_statement.cr
@@ -64,7 +64,7 @@ class LuckyMigrator::AlterTableStatement
     {% end %}
   end
 
-  def add_column(name : Symbol, type : (Bool | String | Time | Int32 | Int64 | Float).class, optional = false, default : ColumnDefaultType? = nil, options : NamedTuple? = nil)
+  def add_column(name : Symbol, type : ColumnType, optional = false, default : ColumnDefaultType? = nil, options : NamedTuple? = nil)
     if options
       column_type_with_options = column_type(type, **options)
     else

--- a/src/lucky_migrator/alter_table_statement.cr
+++ b/src/lucky_migrator/alter_table_statement.cr
@@ -54,9 +54,12 @@ class LuckyMigrator::AlterTableStatement
     {% options = type_options.empty? ? nil : type_options %}
 
     {% if type_declaration.type.is_a?(Union) %}
-      add_column :{{ type_declaration.var }}, {{ type_declaration.type.types.first }}, optional: true, default: {{ default }}, options: {{ options }}
+      add_column :{{ type_declaration.var }}, {{ type_declaration.type.types.first }}, true, default: {{ default }}, options: {{ options }}
     {% else %}
-      add_column :{{ type_declaration.var }}, {{ type_declaration.type }}, default: {{ default }}, options: {{ options }}
+      if {{ default }}.nil?
+        raise "must provide a default value when adding a required column"
+      end
+      add_column :{{ type_declaration.var }}, {{ type_declaration.type }}, false, default: {{ default }}, options: {{ options }}
     {% end %}
 
     {% if index || unique %}

--- a/src/lucky_migrator/column_default_helpers.cr
+++ b/src/lucky_migrator/column_default_helpers.cr
@@ -1,43 +1,47 @@
 module LuckyMigrator::ColumnDefaultHelpers
   alias ColumnDefaultType = String | Time | Int32 | Int64 | Float32 | Float64 | Bool | Symbol
 
-  def value_to_string(value : String | Time)
+  def value_to_string(type : String.class | Time.class, value : String | Time)
     "'#{value}'"
   end
 
-  def value_to_string(value : Int32 | Int64 | Float | Bool)
+  def value_to_string(type : Int32.class | Int64.class | Float.class | Bool.class, value : Int32 | Int64 | Float | Bool)
     "#{value}"
   end
 
+  def value_to_string(type : Time.class, value : Symbol)
+    if value == :now
+      "NOW()"
+    else
+      raise "Unrecognized value :#{value} for a timestamptz. Please use :now for current timestamp."
+    end
+  end
+
   def default_value(type : String.class, default : String)
-    " DEFAULT #{value_to_string(default)}"
+    " DEFAULT #{value_to_string(type, default)}"
   end
 
   def default_value(type : Int64.class, default : Int32 | Int64)
-    " DEFAULT #{value_to_string(default)}"
+    " DEFAULT #{value_to_string(type, default)}"
   end
 
   def default_value(type : Int32.class, default : Int32)
-    " DEFAULT #{value_to_string(default)}"
+    " DEFAULT #{value_to_string(type, default)}"
   end
 
   def default_value(type : Bool.class, default : Bool)
-    " DEFAULT #{value_to_string(default)}"
+    " DEFAULT #{value_to_string(type, default)}"
   end
 
   def default_value(type : Float.class, default : Float)
-    " DEFAULT #{value_to_string(default)}"
+    " DEFAULT #{value_to_string(type, default)}"
   end
 
   def default_value(type : Time.class, default : Time)
-    " DEFAULT #{value_to_string(default.to_utc)}"
+    " DEFAULT #{value_to_string(type, default.to_utc)}"
   end
 
   def default_value(type : Time.class, default : Symbol)
-    if default == :now
-      " DEFAULT NOW()"
-    else
-      raise "Unrecognized default value #{default} for a timestamptz. Please use :now for current timestamp."
-    end
+    " DEFAULT #{value_to_string(type, default)}"
   end
 end

--- a/src/lucky_migrator/column_default_helpers.cr
+++ b/src/lucky_migrator/column_default_helpers.cr
@@ -1,28 +1,36 @@
 module LuckyMigrator::ColumnDefaultHelpers
   alias ColumnDefaultType = String | Time | Int32 | Int64 | Float32 | Float64 | Bool | Symbol
 
+  def value_to_string(value : String | Time)
+    "'#{value}'"
+  end
+
+  def value_to_string(value : Int32 | Int64 | Float | Bool)
+    "#{value}"
+  end
+
   def default_value(type : String.class, default : String)
-    " DEFAULT '#{default}'"
+    " DEFAULT #{value_to_string(default)}"
   end
 
   def default_value(type : Int64.class, default : Int32 | Int64)
-    " DEFAULT #{default}"
+    " DEFAULT #{value_to_string(default)}"
   end
 
   def default_value(type : Int32.class, default : Int32)
-    " DEFAULT #{default}"
+    " DEFAULT #{value_to_string(default)}"
   end
 
   def default_value(type : Bool.class, default : Bool)
-    " DEFAULT #{default}"
+    " DEFAULT #{value_to_string(default)}"
   end
 
   def default_value(type : Float.class, default : Float)
-    " DEFAULT #{default}"
+    " DEFAULT #{value_to_string(default)}"
   end
 
   def default_value(type : Time.class, default : Time)
-    " DEFAULT '#{default.to_utc}'"
+    " DEFAULT #{value_to_string(default.to_utc)}"
   end
 
   def default_value(type : Time.class, default : Symbol)


### PR DESCRIPTION
Closes #12.

One awkward thing is that I used the `default_value` method to serialize the fill_existing_with value: `val = default_value(value.class, value).gsub(" DEFAULT ", "")`. Should we refactor the serializing into a new class?

Also I aggregated the alter table specs to remove repetition and it's pretty large now.