### PR TITLE
Fix formatting of heredoc in macro

### DIFF
--- a/src/lucky_migrator/alter_table_statement.cr
+++ b/src/lucky_migrator/alter_table_statement.cr
@@ -101,7 +101,8 @@ class LuckyMigrator::AlterTableStatement
             ▸ add #{type_declaration.var} : #{type_declaration.type}, default: "Something"
             ▸ add #{type_declaration.var} : #{type_declaration.type}, fill_existing_with: "Something"
             ▸ add #{type_declaration.var} : #{type_declaration.type}, fill_existing_with: :nothing
-          ERROR %}
+          ERROR
+        %}
       {% end %}
 
       {% if default && fill_existing_with %}


### PR DESCRIPTION
Ref: crystal-lang/crystal#6121

This change is compatible with 0.24.2 but not with the formatter.

Besides this change, an updated reference to lucky_cli and lucky_record will be needed for crystal 0.25.0