### PR TITLE
Allow empty table statements, fixes #105

### DIFF
--- a/spec/create_table_statement_spec.cr
+++ b/spec/create_table_statement_spec.cr
@@ -1,6 +1,19 @@
 require "./spec_helper"
 
 describe LuckyMigrator::CreateTableStatement do
+  it "can create tables with no user defined columns" do
+    built = LuckyMigrator::CreateTableStatement.new(:users).build do
+    end
+
+    built.statements.size.should eq 1
+    built.statements.first.should eq <<-SQL
+    CREATE TABLE users (
+      id serial PRIMARY KEY,
+      created_at timestamptz NOT NULL,
+      updated_at timestamptz NOT NULL);
+    SQL
+  end
+
   it "can create tables" do
     built = LuckyMigrator::CreateTableStatement.new(:users).build do
       add name : String

--- a/src/lucky_migrator/create_table_statement.cr
+++ b/src/lucky_migrator/create_table_statement.cr
@@ -56,7 +56,7 @@ class LuckyMigrator::CreateTableStatement
   private def table_statement
     String.build do |statement|
       statement << initial_table_statement
-      statement << "\n"
+      statement << ",\n" unless rows.empty?
 
       statement << rows.join(",\n")
       statement << ");"
@@ -73,7 +73,7 @@ class LuckyMigrator::CreateTableStatement
     CREATE TABLE #{@table_name} (
       id #{id_column_type} PRIMARY KEY,
       created_at timestamptz NOT NULL,
-      updated_at timestamptz NOT NULL,
+      updated_at timestamptz NOT NULL
     SQL
   end
 


### PR DESCRIPTION
We kinda need this for some of the spec support migrations in lucky_record since I didn't give all of the fixture models additional columns :)