### PR TITLE
Use `SET NULL` instead of `NULLIFY`.

### DIFF
--- a/spec/alter_table_statement_spec.cr
+++ b/spec/alter_table_statement_spec.cr
@@ -55,7 +55,7 @@ describe LuckyMigrator::AlterTableStatement do
       ALTER TABLE comments
         ADD user_id int NOT NULL REFERENCES users ON DELETE CASCADE,
         ADD post_id int REFERENCES posts ON DELETE RESTRICT,
-        ADD category_label_id int NOT NULL REFERENCES custom_table ON DELETE NULLIFY,
+        ADD category_label_id int NOT NULL REFERENCES custom_table ON DELETE SET NULL,
         ADD employee_id int NOT NULL REFERENCES users ON DELETE CASCADE
       SQL
 

--- a/spec/create_foreign_key_statement_spec.cr
+++ b/spec/create_foreign_key_statement_spec.cr
@@ -1,9 +1,14 @@
 require "./spec_helper"
 
 describe LuckyMigrator::CreateForeignKeyStatement do
-  it "generates correct sql" do
+  it "generates correct sql with cascade strategy" do
     statement = LuckyMigrator::CreateForeignKeyStatement.new(:comments, :users, column: :author_id, on_delete: :cascade, primary_key: :uid).build
     statement.should eq "ALTER TABLE comments ADD CONSTRAINT comments_author_id_fk FOREIGN KEY (author_id) REFERENCES users (uid) ON DELETE CASCADE;"
+  end
+
+  it "generates correct sql with nullify strategy" do
+    statement = LuckyMigrator::CreateForeignKeyStatement.new(:comments, :users, column: :author_id, on_delete: :nullify, primary_key: :uid).build
+    statement.should eq "ALTER TABLE comments ADD CONSTRAINT comments_author_id_fk FOREIGN KEY (author_id) REFERENCES users (uid) ON DELETE SET NULL;"
   end
 
   it "raises error on invalid on_delete strategy" do

--- a/spec/create_table_statement_spec.cr
+++ b/spec/create_table_statement_spec.cr
@@ -142,7 +142,7 @@ describe LuckyMigrator::CreateTableStatement do
         updated_at timestamptz NOT NULL,
         user_id int NOT NULL REFERENCES users ON DELETE CASCADE,
         post_id int REFERENCES posts ON DELETE RESTRICT,
-        category_label_id int NOT NULL REFERENCES custom_table ON DELETE NULLIFY,
+        category_label_id int NOT NULL REFERENCES custom_table ON DELETE SET NULL,
         employee_id int NOT NULL REFERENCES users ON DELETE CASCADE);
       SQL
 

--- a/src/lucky_migrator/create_foreign_key_statement.cr
+++ b/src/lucky_migrator/create_foreign_key_statement.cr
@@ -7,7 +7,7 @@
 # # => "ALTER TABLE comments ADD CONSTRAINT comments_author_id_fk FOREIGN KEY (author_id) REFERENCES users (uid) ON DELETE CASCADE;"
 # ```
 class LuckyMigrator::CreateForeignKeyStatement
-  ALLOWED_ON_DELETE_STRATEGIES = %i[cascade restrict nullify]
+  include ReferencesHelper
 
   def initialize(@from : Symbol, @to : Symbol, @on_delete : Symbol, @column : Symbol? = nil, @primary_key = :id)
   end
@@ -26,12 +26,10 @@ class LuckyMigrator::CreateForeignKeyStatement
   end
 
   def on_delete_strategy(strategy : Symbol)
-    if ALLOWED_ON_DELETE_STRATEGIES.includes?(strategy)
-      return " ON DELETE" + " #{strategy}".upcase
-    elsif strategy == :do_nothing
+    if strategy == :do_nothing
       return ""
     else
-      raise "on_delete: :#{strategy} is not supported. Please use :do_nothing, :cascade, :restrict, or :nullify"
+      return " ON DELETE " + on_delete_sql(strategy)
     end
   end
 end

--- a/src/lucky_migrator/references_helper.cr
+++ b/src/lucky_migrator/references_helper.cr
@@ -5,7 +5,7 @@ module LuckyMigrator::ReferencesHelper
     elsif on_delete == :do_nothing
       " REFERENCES #{table_name}"
     else
-      " REFERENCES #{table_name}" + " ON DELETE " + on_delete_sql(on_delete) 
+      " REFERENCES #{table_name}" + " ON DELETE " + on_delete_sql(on_delete)
     end
   end
 

--- a/src/lucky_migrator/references_helper.cr
+++ b/src/lucky_migrator/references_helper.cr
@@ -4,8 +4,17 @@ module LuckyMigrator::ReferencesHelper
       ""
     elsif on_delete == :do_nothing
       " REFERENCES #{table_name}"
-    elsif CreateForeignKeyStatement::ALLOWED_ON_DELETE_STRATEGIES.includes?(on_delete)
-      " REFERENCES #{table_name}" + " ON DELETE " + "#{on_delete}".upcase
+    else
+      " REFERENCES #{table_name}" + " ON DELETE " + on_delete_sql(on_delete) 
+    end
+  end
+
+  private def on_delete_sql(on_delete : Symbol?) : String
+    case on_delete
+    when :nullify
+      "SET NULL"
+    when :cascade, :restrict
+      on_delete.to_s.upcase
     else
       raise "on_delete: :#{on_delete} is not supported. Please use :do_nothing, :cascade, :restrict, or :nullify"
     end


### PR DESCRIPTION
I am finally able to spend some time with Lucky again and promptly ran into #111 today.

It seems @jmufugi is right: According to https://www.postgresql.org/docs/9.5/static/ddl-constraints.html the correct SQL syntax is "SET NULL" and not "NULLIFY".

Of course it makes sense to keep `:nullify` as the option name, as people might recognize this coming from rails.

This PR tries to solve this problem. I hope the fix is OK. It has been some time since I dabbled in crystal and I feel I am not yet up to speed again.

And once again thanks for the excellent work on lucky - I still like it very much.