### PR TITLE
UUID reference helpers

### DIFF
--- a/spec/alter_table_statement_spec.cr
+++ b/spec/alter_table_statement_spec.cr
@@ -49,6 +49,7 @@ describe LuckyMigrator::AlterTableStatement do
         add_belongs_to post : Post?, on_delete: :restrict
         add_belongs_to category_label : CategoryLabel, on_delete: :nullify, references: :custom_table
         add_belongs_to employee : User, on_delete: :cascade
+        add_belongs_to line_item : LineItem, on_delete: :cascade, foreign_key_type: LuckyMigrator::PrimaryKeyType::UUID
       end
 
       built.statements.first.should eq <<-SQL
@@ -56,7 +57,8 @@ describe LuckyMigrator::AlterTableStatement do
         ADD user_id int NOT NULL REFERENCES users ON DELETE CASCADE,
         ADD post_id int REFERENCES posts ON DELETE RESTRICT,
         ADD category_label_id int NOT NULL REFERENCES custom_table ON DELETE SET NULL,
-        ADD employee_id int NOT NULL REFERENCES users ON DELETE CASCADE
+        ADD employee_id int NOT NULL REFERENCES users ON DELETE CASCADE,
+        ADD line_item_id uuid NOT NULL REFERENCES line_items ON DELETE CASCADE
       SQL
 
       built.statements[1].should eq "CREATE INDEX comments_user_id_index ON comments USING btree (user_id);"

--- a/spec/alter_table_statement_spec.cr
+++ b/spec/alter_table_statement_spec.cr
@@ -65,6 +65,7 @@ describe LuckyMigrator::AlterTableStatement do
       built.statements[2].should eq "CREATE INDEX comments_post_id_index ON comments USING btree (post_id);"
       built.statements[3].should eq "CREATE INDEX comments_category_label_id_index ON comments USING btree (category_label_id);"
       built.statements[4].should eq "CREATE INDEX comments_employee_id_index ON comments USING btree (employee_id);"
+      built.statements[5].should eq "CREATE INDEX comments_line_item_id_index ON comments USING btree (line_item_id);"
     end
 
     it "raises error when on_delete strategy is invalid or nil" do

--- a/spec/create_table_statement_spec.cr
+++ b/spec/create_table_statement_spec.cr
@@ -135,6 +135,7 @@ describe LuckyMigrator::CreateTableStatement do
         add_belongs_to post : Post?, on_delete: :restrict
         add_belongs_to category_label : CategoryLabel, on_delete: :nullify, references: :custom_table
         add_belongs_to employee : User, on_delete: :cascade
+        add_belongs_to line_item : LineItem, on_delete: :cascade, foreign_key_type: LuckyMigrator::PrimaryKeyType::UUID
       end
 
       built.statements.first.should eq <<-SQL
@@ -145,7 +146,8 @@ describe LuckyMigrator::CreateTableStatement do
         user_id int NOT NULL REFERENCES users ON DELETE CASCADE,
         post_id int REFERENCES posts ON DELETE RESTRICT,
         category_label_id int NOT NULL REFERENCES custom_table ON DELETE SET NULL,
-        employee_id int NOT NULL REFERENCES users ON DELETE CASCADE);
+        employee_id int NOT NULL REFERENCES users ON DELETE CASCADE,
+        line_item_id uuid NOT NULL REFERENCES line_items ON DELETE CASCADE);
       SQL
 
       built.statements[1].should eq "CREATE INDEX comments_user_id_index ON comments USING btree (user_id);"

--- a/spec/create_table_statement_spec.cr
+++ b/spec/create_table_statement_spec.cr
@@ -154,6 +154,7 @@ describe LuckyMigrator::CreateTableStatement do
       built.statements[2].should eq "CREATE INDEX comments_post_id_index ON comments USING btree (post_id);"
       built.statements[3].should eq "CREATE INDEX comments_category_label_id_index ON comments USING btree (category_label_id);"
       built.statements[4].should eq "CREATE INDEX comments_employee_id_index ON comments USING btree (employee_id);"
+      built.statements[5].should eq "CREATE INDEX comments_line_item_id_index ON comments USING btree (line_item_id);"
     end
 
     it "raises error when on_delete strategy is invalid or nil" do

--- a/src/lucky_migrator/alter_table_statement.cr
+++ b/src/lucky_migrator/alter_table_statement.cr
@@ -54,7 +54,7 @@ class LuckyMigrator::AlterTableStatement
   end
 
   # Adds a references column and index given a model class and references option.
-  macro add_belongs_to(type_declaration, on_delete, references = nil)
+  macro add_belongs_to(type_declaration, on_delete, references = nil, foreign_key_type = LuckyMigrator::PrimaryKeyType::Serial)
     {% unless type_declaration.is_a?(TypeDeclaration) %}
       {% raise "add_belongs_to expected a type declaration like 'user : User', instead got: '#{type_declaration}'" %}
     {% end %}
@@ -71,7 +71,7 @@ class LuckyMigrator::AlterTableStatement
 
     add_index :{{ foreign_key_name }}
     add_column :{{ foreign_key_name }},
-      type: Int32,
+      type: {{ foreign_key_type }}.db_type,
       optional: {{ optional }},
       default: nil,
       fill_existing_with: nil,

--- a/src/lucky_migrator/create_table_statement.cr
+++ b/src/lucky_migrator/create_table_statement.cr
@@ -112,7 +112,7 @@ class LuckyMigrator::CreateTableStatement
   end
 
   # Adds a references column and index given a model class and references option.
-  macro add_belongs_to(type_declaration, on_delete, references = nil)
+  macro add_belongs_to(type_declaration, on_delete, references = nil, foreign_key_type = LuckyMigrator::PrimaryKeyType::Serial)
     {% unless type_declaration.is_a?(TypeDeclaration) %}
       {% raise "add_belongs_to expected a type declaration like 'user : User', instead got: '#{type_declaration}'" %}
     {% end %}
@@ -126,8 +126,7 @@ class LuckyMigrator::CreateTableStatement
 
     {% foreign_key_name = type_declaration.var + "_id" %}
     %table_name = {{ references }} || LuckyInflector::Inflector.pluralize({{ underscored_class }})
-
-    add_column :{{ foreign_key_name }}, Int32, {{ optional }}, reference: %table_name, on_delete: {{ on_delete }}
+    add_column(:{{ foreign_key_name }}, {{ foreign_key_type.id }}.db_type, {{ optional }}, reference: %table_name, on_delete: {{ on_delete }})
     add_index :{{ foreign_key_name }}
   end
 

--- a/src/lucky_migrator/primary_key_type.cr
+++ b/src/lucky_migrator/primary_key_type.cr
@@ -1,7 +1,7 @@
 module LuckyMigrator
   private PRIMARY_KEY_TO_COLUMN_TYPE_MAPPING = {
     LuckyMigrator::PrimaryKeyType::Serial => Int32,
-    LuckyMigrator::PrimaryKeyType::UUID => ::UUID,
+    LuckyMigrator::PrimaryKeyType::UUID   => ::UUID,
   }
 
   enum PrimaryKeyType

--- a/src/lucky_migrator/primary_key_type.cr
+++ b/src/lucky_migrator/primary_key_type.cr
@@ -2,5 +2,13 @@ module LuckyMigrator
   enum PrimaryKeyType
     Serial
     UUID
+
+    def db_type
+      if self == UUID
+        ::UUID
+      else
+        Int32
+      end
+    end
   end
 end

--- a/src/lucky_migrator/primary_key_type.cr
+++ b/src/lucky_migrator/primary_key_type.cr
@@ -1,14 +1,15 @@
 module LuckyMigrator
+  private PRIMARY_KEY_TO_COLUMN_TYPE_MAPPING = {
+    LuckyMigrator::PrimaryKeyType::Serial => Int32,
+    LuckyMigrator::PrimaryKeyType::UUID => ::UUID,
+  }
+
   enum PrimaryKeyType
     Serial
     UUID
 
     def db_type
-      if self == UUID
-        ::UUID
-      else
-        Int32
-      end
+      PRIMARY_KEY_TO_COLUMN_TYPE_MAPPING[self]
     end
   end
 end


### PR DESCRIPTION
Closes #113, adds 

```crystal
alter :foo do
  add_belongs_to line_item : LineItem, on_delete: :cascade, foreign_key_type: LuckyMigrator::PrimaryKeyType::UUID
end
```

as well as 

```crystal
create :foo do
  add_belongs_to line_item : LineItem, on_delete: :cascade, foreign_key_type: LuckyMigrator::PrimaryKeyType::UUID
end
```

I did _not_ infer the primary key type for now. For once it was not that trivial, since it would've meant again messing with the `finished` macro and _storing_ the reference instead of directly just outputting the method calls in macros. I guess we can alway infer later 🤷🏼‍♂️?