### PR TITLE
Add --quiet option on DB::Create and DB::Migrate

### DIFF
--- a/spec/migration_spec.cr
+++ b/spec/migration_spec.cr
@@ -45,11 +45,11 @@ describe LuckyMigrator::Migration::V1 do
 
   describe "statement execution order" do
     Spec.after_each do
-      MigrationWithOrderDependentExecute::V998.new.down(log: false)
+      MigrationWithOrderDependentExecute::V998.new.down(quiet: true)
     end
 
     it "runs execute statements in the order they were called" do
-      MigrationWithOrderDependentExecute::V998.new.up(log: false)
+      MigrationWithOrderDependentExecute::V998.new.up(quiet: true)
       columns = get_column_names("execution_order")
       columns.includes?("new_col").should be_true
       columns.includes?("bar").should be_true

--- a/src/lucky_migrator/migration.cr
+++ b/src/lucky_migrator/migration.cr
@@ -25,7 +25,7 @@ abstract class LuckyMigrator::Migration::V1
   # helpers to generate and collect SQL statements in the
   # @prepared_statements array. Each statement is then executed in  a
   # transaction and tracked upon completion.
-  def up(log = true)
+  def up(quiet = false)
     if migrated?
       puts "Already migrated #{self.class.name.colorize(:cyan)}"
     else
@@ -33,7 +33,7 @@ abstract class LuckyMigrator::Migration::V1
       migrate
       execute_in_transaction @prepared_statements do |tx|
         track_migration(tx)
-        if log
+        unless quiet
           puts "Migrated #{self.class.name.colorize(:green)}"
         end
       end
@@ -41,7 +41,7 @@ abstract class LuckyMigrator::Migration::V1
   end
 
   # Same as #up except calls rollback method in migration.
-  def down(log = true)
+  def down(quiet = false)
     if pending?
       puts "Already rolled back #{self.class.name.colorize(:cyan)}"
     else
@@ -49,7 +49,7 @@ abstract class LuckyMigrator::Migration::V1
       rollback
       execute_in_transaction @prepared_statements do |tx|
         untrack_migration(tx)
-        if log
+        unless quiet
           puts "Rolled back #{self.class.name.colorize(:green)}"
         end
       end

--- a/src/lucky_migrator/runner.cr
+++ b/src/lucky_migrator/runner.cr
@@ -9,6 +9,9 @@ class LuckyMigrator::Runner
 
   @@migrations = [] of LuckyMigrator::Migration::V1.class
 
+  def initialize(@quiet : Bool = false)
+  end
+
   Habitat.create do
     setting database : String
   end
@@ -53,9 +56,11 @@ class LuckyMigrator::Runner
     end
   end
 
-  def self.create_db
+  def self.create_db(quiet? : Bool = false)
     run "createdb #{self.cmd_args}"
-    puts "Done creating #{LuckyMigrator::Runner.db_name.colorize(:green)}"
+    unless quiet?
+      puts "Done creating #{LuckyMigrator::Runner.db_name.colorize(:green)}"
+    end
   rescue e : Exception
     if (message = e.message) && message.includes?(%("#{self.db_name}" already exists))
       puts "Already created #{self.db_name.colorize(:green)}"

--- a/src/lucky_migrator/runner.cr
+++ b/src/lucky_migrator/runner.cr
@@ -63,7 +63,9 @@ class LuckyMigrator::Runner
     end
   rescue e : Exception
     if (message = e.message) && message.includes?(%("#{self.db_name}" already exists))
-      puts "Already created #{self.db_name.colorize(:green)}"
+      unless quiet?
+        puts "Already created #{self.db_name.colorize(:green)}"
+      end
     elsif (message = e.message) && (message.includes?("createdb: not found") || message.includes?("No command 'createdb' found"))
       raise <<-ERROR
       #{message}
@@ -100,7 +102,7 @@ class LuckyMigrator::Runner
 
   def run_pending_migrations
     prepare_for_migration do
-      pending_migrations.each &.new.up(!@quiet)
+      pending_migrations.each &.new.up(log: !@quiet)
     end
   end
 
@@ -147,7 +149,9 @@ class LuckyMigrator::Runner
   private def prepare_for_migration
     setup_migration_tracking_tables
     if pending_migrations.empty?
-      puts "Did nothing. No pending migrations.".colorize(:green)
+      unless @quiet
+        puts "Did nothing. No pending migrations.".colorize(:green)
+      end
     else
       yield
     end

--- a/src/lucky_migrator/runner.cr
+++ b/src/lucky_migrator/runner.cr
@@ -102,7 +102,7 @@ class LuckyMigrator::Runner
 
   def run_pending_migrations
     prepare_for_migration do
-      pending_migrations.each &.new.up(log: !@quiet)
+      pending_migrations.each &.new.up(@quiet)
     end
   end
 

--- a/src/lucky_migrator/runner.cr
+++ b/src/lucky_migrator/runner.cr
@@ -100,7 +100,7 @@ class LuckyMigrator::Runner
 
   def run_pending_migrations
     prepare_for_migration do
-      pending_migrations.each &.new.up
+      pending_migrations.each &.new.up(!@quiet)
     end
   end
 

--- a/src/lucky_migrator/tasks/db/create.cr
+++ b/src/lucky_migrator/tasks/db/create.cr
@@ -2,23 +2,12 @@ class Db::Create < LuckyCli::Task
   banner "Create the database"
 
   def initialize(@quiet : Bool = false)
-    parse_options
+    @quiet = ARGV.includes? "--quiet"
   end
 
   def call
     LuckyMigrator.run do
       LuckyMigrator::Runner.create_db(@quiet)
-    end
-  end
-
-  private def parse_options
-    OptionParser.parse! do |parser|
-      parser.banner = "Usage: lucky db.create [arguments]"
-      parser.on("--quiet", "Doesn't print success output") { @quiet = true }
-      parser.on("-h", "--help", "Help here") {
-        puts parser
-        exit(0)
-      }
     end
   end
 end

--- a/src/lucky_migrator/tasks/db/create.cr
+++ b/src/lucky_migrator/tasks/db/create.cr
@@ -13,7 +13,7 @@ class Db::Create < LuckyCli::Task
 
   private def parse_options
     OptionParser.parse! do |parser|
-      parser.banner = "Usage: lucky db.migrate [arguments]"
+      parser.banner = "Usage: lucky db.create [arguments]"
       parser.on("--quiet", "Doesn't print success output") { @quiet = true }
       parser.on("-h", "--help", "Help here") {
         puts parser

--- a/src/lucky_migrator/tasks/db/create.cr
+++ b/src/lucky_migrator/tasks/db/create.cr
@@ -2,7 +2,6 @@ class Db::Create < LuckyCli::Task
   banner "Create the database"
 
   def initialize(@quiet : Bool = false)
-    @quiet = ARGV.includes? "--quiet"
   end
 
   def call

--- a/src/lucky_migrator/tasks/db/create.cr
+++ b/src/lucky_migrator/tasks/db/create.cr
@@ -1,11 +1,24 @@
-require "colorize"
-
 class Db::Create < LuckyCli::Task
   banner "Create the database"
 
+  def initialize(@quiet : Bool = false)
+    parse_options
+  end
+
   def call
     LuckyMigrator.run do
-      LuckyMigrator::Runner.create_db
+      LuckyMigrator::Runner.create_db(@quiet)
+    end
+  end
+
+  private def parse_options
+    OptionParser.parse! do |parser|
+      parser.banner = "Usage: lucky db.migrate [arguments]"
+      parser.on("--quiet", "Doesn't print success output") { @quiet = true }
+      parser.on("-h", "--help", "Help here") {
+        puts parser
+        exit(0)
+      }
     end
   end
 end

--- a/src/lucky_migrator/tasks/db/migrate.cr
+++ b/src/lucky_migrator/tasks/db/migrate.cr
@@ -4,7 +4,6 @@ class Db::Migrate < LuckyCli::Task
   banner "Migrate the database"
 
   def initialize(@quiet : Bool = false)
-    @quiet = ARGV.includes? "--quiet"
   end
 
   def call(args = ARGV)

--- a/src/lucky_migrator/tasks/db/migrate.cr
+++ b/src/lucky_migrator/tasks/db/migrate.cr
@@ -6,7 +6,7 @@ class Db::Migrate < LuckyCli::Task
   def initialize(@quiet : Bool = false)
   end
 
-  def call(args = ARGV)
+  def call
     LuckyMigrator.run do
       LuckyMigrator::Runner.new(@quiet).run_pending_migrations
     end

--- a/src/lucky_migrator/tasks/db/migrate.cr
+++ b/src/lucky_migrator/tasks/db/migrate.cr
@@ -3,9 +3,13 @@ require "colorize"
 class Db::Migrate < LuckyCli::Task
   banner "Migrate the database"
 
-  def call
+  def initialize(@quiet : Bool = false)
+    @quiet = ARGV.includes? "--quiet"
+  end
+
+  def call(args = ARGV)
     LuckyMigrator.run do
-      LuckyMigrator::Runner.new.run_pending_migrations
+      LuckyMigrator::Runner.new(@quiet).run_pending_migrations
     end
   end
 end


### PR DESCRIPTION
I used ARGV to check for the `--quiet` option, set the `@quiet` var and passed that to the runner.