### PR TITLE
Added schema class variable to migration and runner classes

### DIFF
--- a/src/lucky_migrator/runner.cr
+++ b/src/lucky_migrator/runner.cr
@@ -150,7 +150,7 @@ class LuckyMigrator::Runner
     @@migrations.select &.new.pending?
   end
 
-  private def setup_migration_tracking_tables
+  def setup_migration_tracking_tables
     DB.open(LuckyRecord::Repo.settings.url) do |db|
       db.exec create_schema unless @@schema == "public"
       db.exec set_schema unless @@schema == "public"


### PR DESCRIPTION
This PR allows to set a custom schema to run the migrations.
Sample snippet for migrations on multi tenant architecture:

```crystal
class Apartment::Migrate < LuckyCli::Task
  banner "Migrate all tenants"

  def call
    if Apartment.settings.active
      tenants = Apartment.settings.tenant_names
      tenants.each do |tenant|
        LuckyMigrator.run do
          LuckyMigrator::Runner.schema = tenant
          LuckyMigrator::Runner.new(true).run_pending_migrations
        end
      end
    end
    puts "Done"
  end
end
```