### PR TITLE
Add `./bin/setup` script

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ This will create a timestamped migration in `db/migrations`
 To run the tests:
 
 * Install Postgres: ([macOS](https://postgresapp.com)/[Others](https://wiki.postgresql.org/wiki/Detailed_installation_guides))
-* Migrate the database using `lucky db.create && lucky db.migrate`
+* Install shards and set up the databases with `./bin/setup`
 * Run the tests with `crystal spec`
 
 ## Contributors

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,7 @@
+#! /bin/sh
+
+set -e
+
+shards install
+lucky db.create
+lucky db.migrate


### PR DESCRIPTION
Because anyone coming into the project hoping to contribute should be
able to get up and running as quick as possible.

I relatively quickly figured out what I needed to run but it wasn't
necessarily right off the bat.