### PR TITLE
Support one or more columns when creating an index

### DIFF
--- a/db/migrations/001_create_users.cr
+++ b/db/migrations/001_create_users.cr
@@ -12,7 +12,7 @@ class CreateUsers::V001 < LuckyMigrator::Migration::V1
 
     execute "CREATE INDEX users_num_index ON users USING btree (num);"
 
-    create_index :users, :last_name, unique: true
+    create_index :users, [:first_name, :last_name], unique: true
   end
 
   def rollback

--- a/spec/create_index_statement_spec.cr
+++ b/spec/create_index_statement_spec.cr
@@ -1,11 +1,16 @@
 require "./spec_helper"
 
 describe LuckyMigrator::CreateIndexStatement do
-  it "generates correct sql" do
+  it "generates correct CREATE INDEX sql" do
     statement = LuckyMigrator::CreateIndexStatement.new(:users, :email).build
     statement.should eq "CREATE INDEX users_email_index ON users USING btree (email);"
 
-    statement = LuckyMigrator::CreateIndexStatement.new(:users, column: :email, using: :btree, unique: true).build
+    statement = LuckyMigrator::CreateIndexStatement.new(:users, columns: :email, using: :btree, unique: true).build
     statement.should eq "CREATE UNIQUE INDEX users_email_index ON users USING btree (email);"
+  end
+
+  it "generates correct multi-column index sql" do
+    statement = LuckyMigrator::CreateIndexStatement.new(:users, columns: [:email, :username], using: :btree, unique: true).build
+    statement.should eq "CREATE UNIQUE INDEX users_email_username_index ON users USING btree (email, username);"
   end
 end

--- a/spec/drop_index_statement_spec.cr
+++ b/spec/drop_index_statement_spec.cr
@@ -1,8 +1,13 @@
 require "./spec_helper"
 
 describe LuckyMigrator::DropIndexStatement do
-  it "generates correct sql" do
+  it "generates correct sql for single column" do
     statement = LuckyMigrator::DropIndexStatement.new(:users, :email, on_delete: :cascade, if_exists: true).build
     statement.should eq "DROP INDEX IF EXISTS users_email_index CASCADE;"
+  end
+
+  it "generates correct sql for multiple columns" do
+    statement = LuckyMigrator::DropIndexStatement.new(:users, [:email, :username], on_delete: :cascade, if_exists: true).build
+    statement.should eq "DROP INDEX IF EXISTS users_email_username_index CASCADE;"
   end
 end

--- a/src/lucky_migrator/create_index_statement.cr
+++ b/src/lucky_migrator/create_index_statement.cr
@@ -1,16 +1,29 @@
-# Builds an SQL statement for creating an index using table name, column name,
-# index type and unique flag.
+require "./index_statement_helpers"
+
+# Builds an SQL statement for creating an index using table name, column
+# name(s), index type and unique flag.
 #
 # ### Usage
 #
+# For a single column:
+#
 # ```
-# CreateIndexStatement.new(:users, column: :email, using: :btree, unique: true).build
+# CreateIndexStatement.new(:users, columns: :email, using: :btree, unique: true).build
 # # => "CREATE UNIQUE INDEX users_email_index ON users USING btree (email);"
 # ```
+#
+# For multiple columns:
+#
+# ```
+# CreateIndexStatement.new(:users, columns: [:email, :username], using: :btree, unique: true).build
+# # => "CREATE UNIQUE INDEX users_email_username_index ON users USING btree (email, username);"
+# ```
 class LuckyMigrator::CreateIndexStatement
+  include LuckyMigrator::IndexStatementHelpers
+
   ALLOWED_INDEX_TYPES = %w[btree]
 
-  def initialize(@table : Symbol, @column : Symbol, @using : Symbol = :btree, @unique = false)
+  def initialize(@table : Symbol, @columns : Columns, @using : Symbol = :btree, @unique = false)
     raise "index type '#{using}' not supported" unless ALLOWED_INDEX_TYPES.includes?(using.to_s)
   end
 
@@ -18,10 +31,20 @@ class LuckyMigrator::CreateIndexStatement
     String.build do |index|
       index << "CREATE"
       index << " UNIQUE" if @unique
-      index << " INDEX #{@table}_#{@column}_index"
+      index << " INDEX #{@table}_#{columns.join("_")}_index"
       index << " ON #{@table}"
       index << " USING #{@using}"
-      index << " (#{@column});"
+      index << " (#{columns.join(", ")});"
+    end
+  end
+
+  private def columns
+    columns = @columns
+
+    if columns.is_a? Array
+      return columns
+    else
+      return [columns]
     end
   end
 end

--- a/src/lucky_migrator/drop_index_statement.cr
+++ b/src/lucky_migrator/drop_index_statement.cr
@@ -1,22 +1,35 @@
-# Builds an SQL statement for dropping an index by inferring it's name using table name and column.
+require "./index_statement_helpers"
+
+# Builds an SQL statement for dropping an index by inferring it's name using table name and column(s).
 #
 # ### Usage
+#
+# For a single column index:
 #
 # ```
 # DropIndexStatement.new(:users, :email, if_exists: true, on_delete: :cascade).build
 # # => "DROP INDEX IF EXISTS users_email_index CASCADE;"
 # ```
+#
+# For multiple column index:
+#
+# ```
+# DropIndexStatement.new(:users, [:email, :username] if_exists: true, on_delete: :cascade).build
+# # => "DROP INDEX IF EXISTS users_email_username_index CASCADE;"
+# ```
 class LuckyMigrator::DropIndexStatement
+  include LuckyMigrator::IndexStatementHelpers
+
   ALLOWED_ON_DELETE_STRATEGIES = %i[cascade restrict]
 
-  def initialize(@table : Symbol, @column : Symbol, @if_exists = false, @on_delete = :do_nothing)
+  def initialize(@table : Symbol, @columns : Columns, @if_exists = false, @on_delete = :do_nothing)
   end
 
   def build
     String.build do |index|
       index << "DROP INDEX"
       index << " IF EXISTS" if @if_exists
-      index << " #{@table}_#{@column}_index"
+      index << " #{@table}_#{columns.join("_")}_index"
       index << on_delete_strategy(@on_delete)
     end
   end
@@ -28,6 +41,16 @@ class LuckyMigrator::DropIndexStatement
       " #{on_delete};".upcase
     else
       raise "on_delete: :#{on_delete} is not supported. Please use :do_nothing, :cascade or :restrict"
+    end
+  end
+
+  private def columns
+    columns = @columns
+
+    if columns.is_a? Array
+      return columns
+    else
+      return [columns]
     end
   end
 end

--- a/src/lucky_migrator/index_statement_helpers.cr
+++ b/src/lucky_migrator/index_statement_helpers.cr
@@ -1,4 +1,6 @@
 module LuckyMigrator::IndexStatementHelpers
+  alias Columns = Symbol | Array(Symbol)
+
   private getter index_statements = [] of String
 
   # Generates raw sql for adding an index to a table column. Accepts 'unique' and 'using' options.

--- a/src/lucky_migrator/statement_helpers.cr
+++ b/src/lucky_migrator/statement_helpers.cr
@@ -1,4 +1,8 @@
+require "./index_statement_helpers"
+
 module LuckyMigrator::StatementHelpers
+  include LuckyMigrator::IndexStatementHelpers
+
   macro create(table_name, primary_key_type = LuckyMigrator::PrimaryKeyType::Serial)
     statements = LuckyMigrator::CreateTableStatement.new({{ table_name }}, {{ primary_key_type }}).build do
       {{ yield }}
@@ -27,12 +31,12 @@ module LuckyMigrator::StatementHelpers
     prepared_statements << CreateForeignKeyStatement.new(from, to, on_delete, column, primary_key).build
   end
 
-  def create_index(table_name : Symbol, column : Symbol, unique = false, using = :btree)
-    prepared_statements << CreateIndexStatement.new(table_name, column, using, unique).build
+  def create_index(table_name : Symbol, columns : Columns, unique = false, using = :btree)
+    prepared_statements << CreateIndexStatement.new(table_name, columns, using, unique).build
   end
 
-  def drop_index(table_name : Symbol, column : Symbol, if_exists = false, on_delete = :do_nothing)
-    prepared_statements << LuckyMigrator::DropIndexStatement.new(table_name, column, if_exists, on_delete).build
+  def drop_index(table_name : Symbol, columns : Columns, if_exists = false, on_delete = :do_nothing)
+    prepared_statements << LuckyMigrator::DropIndexStatement.new(table_name, columns, if_exists, on_delete).build
   end
 
   def make_required(table : Symbol, column : Symbol)


### PR DESCRIPTION
Some indexes need to be applied across multiple columns. This commit
allows us to pass not only one symble, but an array of symbols that can
be used when creating the SQL string.